### PR TITLE
Update doc link & set 'restore_sample_db' when the db is already setup

### DIFF
--- a/liualgotrader/liu
+++ b/liualgotrader/liu
@@ -179,7 +179,7 @@ def quickstart():
 
     if already_have_db:
         print(
-            "Follow the instructions at 'https://liualgotrader.readthedocs.io/en/latest/Installation%20&%20Setup.html#database-setup' to complete your database setup."
+            "Follow the instructions at 'https://liualgotrader.readthedocs.io/en/latest/(Advanced)%20Setup.html#database-setup' to complete your database setup."
         )
     else:
         pwd = pathlib.Path().absolute()

--- a/liualgotrader/liu
+++ b/liualgotrader/liu
@@ -181,6 +181,7 @@ def quickstart():
         print(
             "Follow the instructions at 'https://liualgotrader.readthedocs.io/en/latest/(Advanced)%20Setup.html#database-setup' to complete your database setup."
         )
+        restore_sample_db = False
     else:
         pwd = pathlib.Path().absolute()
         print("Liu Algo Trading Framework uses `docker-compose` to run a local database.")

--- a/liualgotrader/miners/stock_cluster.py
+++ b/liualgotrader/miners/stock_cluster.py
@@ -79,6 +79,7 @@ class StockCluster(Miner):
                 "perpage": 1,
             },
         ) as response:
+            response.raise_for_status()
             return response.json()["count"]
 
     def _fetch(self, session: requests.Session, page: int) -> List[Ticker]:


### PR DESCRIPTION
Hello, thank you for this project.
This MR addresses two small things in the `quickstart`-command:
1) The link to the database-setup is no longer valid
2) the local variable 'restore_sample_db' referenced before assignment when one has already a database setup:
```
Congratulations, Liu Algo Trader is ready to go!
From here, you can either run the back-testing UI, or read the docs.
The full documentation is available here: `https://liualgotrader.rtfd.io`.
Traceback (most recent call last):
  File "/.venv/bin/liu", line 294, in <module>
    quickstart()
  File "/.venv/bin/liu", line 254, in quickstart
    if restore_sample_db:
UnboundLocalError: local variable 'restore_sample_db' referenced before assignment
```

See commits for details.