### PR TITLE
Propagate HTTPError 403 Client Error

### DIFF
--- a/liualgotrader/data/alpaca.py
+++ b/liualgotrader/data/alpaca.py
@@ -392,6 +392,10 @@ class AlpacaData(DataAPI):
                 tlog("retrying")
                 time.sleep(10)
                 return self.get_symbol_data(symbol, start, end, scale)
+            else:
+                raise ValueError(
+                    f"[EXCEPTION] {e} for {symbol} could not obtain data for {_start} to {_end} w {scale.name}"
+                )
 
         except Exception as e:
             raise ValueError(


### PR DESCRIPTION
Propagate `HTTPError: 403 Client Error: Forbidden for url` which otherwise results in a potential confusing exception talking about some None-type not having a index (line 410)
```
[get_symbol_data()][306525]2022-12-20 18:45:44.845780:received HTTPError: 403 Client Error: Forbidden for url: https://data.alpaca.markets/v2/stocks/ADES/bars?some=args
2022-12-20 18:45:44.846 Uncaught app exception
Traceback (most recent call last):
  File "/LiuAlgoTrader/.venv/lib/python3.10/site-packages/streamlit-1.15.1-py3.10.egg/streamlit/runtime/scriptrunner/script_runner.py", line 564, in _run_script
    exec(code, module.__dict__)
  File "/LiuAlgoTrader/analysis/backtester_ui.py", line 98, in <module>
    symbol_data = minute_history[symbol][start_date:end_date]
  File "/LiuAlgoTrader/.venv/lib/python3.10/site-packages/liualgotrader-0.4.29-py3.10.egg/liualgotrader/common/data_loader.py", line 586, in __getitem__
    self.symbol_data, rc = getitem_slice(
  File "/LiuAlgoTrader/.venv/lib/python3.10/site-packages/liualgotrader-0.4.29-py3.10.egg/liualgotrader/common/data_loader.py", line 374, in getitem_slice
    symbol_data = fetch_data_range(
  File "/LiuAlgoTrader/.venv/lib/python3.10/site-packages/liualgotrader-0.4.29-py3.10.egg/liualgotrader/common/data_loader.py", line 310, in fetch_data_range
    return _legacy_fetch_data_range(
  File "/LiuAlgoTrader/.venv/lib/python3.10/site-packages/liualgotrader-0.4.29-py3.10.egg/liualgotrader/common/data_loader.py", line 268, in _legacy_fetch_data_range
    new_df = data_api.get_symbol_data(
  File "/LiuAlgoTrader/.venv/lib/python3.10/site-packages/liualgotrader-0.4.29-py3.10.egg/liualgotrader/data/alpaca.py", line 406, in get_symbol_data
    data.index = data.index.tz_convert("America/New_York")
AttributeError: 'NoneType' object has no attribute 'index'
```